### PR TITLE
Setup support for publishing models

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,8 @@
-source "https://rubygems.org"
+# frozen_string_literal: true
 
-git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+source 'https://rubygems.org'
+
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 # Specify your gem's dependencies in synchronized_model.gemspec
 gemspec

--- a/lib/synchronized_model.rb
+++ b/lib/synchronized_model.rb
@@ -3,5 +3,7 @@
 require 'synchronized_model/version'
 
 module SynchronizedModel
-  # Your code goes here...
+  autoload :Message, 'synchronized_model/message'
+  autoload :PublishMixin, 'synchronized_model/publish_mixin'
+  autoload :Support, 'synchronized_model/support'
 end

--- a/lib/synchronized_model/message.rb
+++ b/lib/synchronized_model/message.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'securerandom'
+
 module SynchronizedModel
   class Message
     include Support

--- a/lib/synchronized_model/message.rb
+++ b/lib/synchronized_model/message.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'securerandom'
+module SynchronizedModel
+  class Message
+    include Support
+    attr_reader :model
+
+    def initialize(model)
+      @model = model
+    end
+
+    def call
+      message
+    end
+
+    protected
+
+    def message
+      {
+        id: SecureRandom.uuid,
+        payload: model.to_message_payload,
+        resource: underscore(model.class.name)
+      }
+    end
+  end
+end

--- a/lib/synchronized_model/publish_mixin.rb
+++ b/lib/synchronized_model/publish_mixin.rb
@@ -3,7 +3,15 @@
 module SynchronizedModel
   module PublishMixin
     def to_message_payload
-      attributes
+      attributes.merge(additional_message_attributes)
+    end
+
+    private
+
+    # This method can be overriden in the model to attach additional
+    # attributes to the message
+    def additional_message_attributes
+      {}
     end
   end
 end

--- a/lib/synchronized_model/publish_mixin.rb
+++ b/lib/synchronized_model/publish_mixin.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module SynchronizedModel
+  module PublishMixin
+    def to_message_payload
+      attributes
+    end
+  end
+end

--- a/lib/synchronized_model/support.rb
+++ b/lib/synchronized_model/support.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+module SynchronizedModel
+  module Support
+    # Taken from ActiveSupport:Inflector.underscore
+    def underscore(camel_cased_word)
+      return camel_cased_word unless /[A-Z-]|::/.match?(camel_cased_word)
+      word = camel_cased_word.to_s.gsub('::', '/')
+      word.gsub!(/([A-Z\d]+)([A-Z][a-z])/, '\1_\2')
+      word.gsub!(/([a-z\d])([A-Z])/, '\1_\2')
+      word.tr!('-', '_')
+      word.downcase!
+      word
+    end
+  end
+end

--- a/spec/lib/synchronized_model/message_spec.rb
+++ b/spec/lib/synchronized_model/message_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+RSpec.describe SynchronizedModel::Message do
+  describe '#call' do
+    let(:expected_payload) do
+      { name: 'John Smith', visits: '12' }
+    end
+    let(:model) do
+      TestModel = Struct.new(:to_message_payload)
+      TestModel.new(expected_payload)
+    end
+
+    subject { SynchronizedModel::Message.new(model).call }
+
+    it 'returns expected message hash' do
+      result = subject
+
+      expect(result[:id].length).to be(36)
+      expect(result[:payload]).to eq(expected_payload)
+      expect(result[:resource]).to eq('test_model')
+    end
+  end
+end

--- a/spec/lib/synchronized_model/publish_mixin_spec.rb
+++ b/spec/lib/synchronized_model/publish_mixin_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+RSpec.describe SynchronizedModel::PublishMixin do
+  class TestClass
+    include SynchronizedModel::PublishMixin
+
+    attr_accessor :attributes
+
+    def initialize(attributes)
+      @attributes = attributes
+    end
+  end
+
+  describe '#to_message_payload' do
+    let(:expected_attributes) do
+      { name: 'John Smith', visits: '12' }
+    end
+
+    subject do
+      TestClass.new(expected_attributes).to_message_payload
+    end
+
+    it 'returns attributes hash' do
+      expect(subject).to eq(expected_attributes)
+    end
+  end
+end

--- a/spec/lib/synchronized_model/publish_mixin_spec.rb
+++ b/spec/lib/synchronized_model/publish_mixin_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 RSpec.describe SynchronizedModel::PublishMixin do
-  class TestClass
+  class TestClassWithNoAdditionalAttributes
     include SynchronizedModel::PublishMixin
 
     attr_accessor :attributes
@@ -12,17 +12,52 @@ RSpec.describe SynchronizedModel::PublishMixin do
     end
   end
 
+  class TestClassWithAdditionalAttributes
+    include SynchronizedModel::PublishMixin
+
+    attr_accessor :attributes
+
+    def initialize(attributes)
+      @attributes = attributes
+    end
+
+    def additional_message_attributes
+      { title: 'Senior' }
+    end
+  end
+
   describe '#to_message_payload' do
     let(:expected_attributes) do
       { name: 'John Smith', visits: '12' }
     end
 
-    subject do
-      TestClass.new(expected_attributes).to_message_payload
+    context 'with no additional attributes' do
+      subject do
+        TestClassWithNoAdditionalAttributes
+          .new(expected_attributes)
+          .to_message_payload
+      end
+
+      it 'returns attributes hash' do
+        expect(subject).to eq(expected_attributes)
+      end
     end
 
-    it 'returns attributes hash' do
-      expect(subject).to eq(expected_attributes)
+    context 'with additional attributes' do
+      let(:expected_additional_attributes) do
+        { title: 'Senior' }
+      end
+
+      subject do
+        TestClassWithAdditionalAttributes
+          .new(expected_attributes)
+          .to_message_payload
+      end
+
+      it 'returns attributes hash' do
+        expect(subject)
+          .to  eq(expected_attributes.merge(expected_additional_attributes))
+      end
     end
   end
 end


### PR DESCRIPTION
Setup support for publish models to SNS.

Add SynchronizedModel::Message for formatting the model into
a standard message.

Add SynchronizedModel::PublishMixin to add the `to_message_payload`
method into models.

needed-by westernmilling/contracto#70