### PR TITLE
Fallback for matches? to support older version of ruby

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    synchronized_model (0.2.0)
+    synchronized_model (0.2.1)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/synchronized_model/support.rb
+++ b/lib/synchronized_model/support.rb
@@ -3,13 +3,29 @@ module SynchronizedModel
   module Support
     # Taken from ActiveSupport:Inflector.underscore
     def underscore(camel_cased_word)
-      return camel_cased_word unless /[A-Z-]|::/.match?(camel_cased_word)
+      return camel_cased_word unless matches_wrapper(camel_cased_word)
       word = camel_cased_word.to_s.gsub('::', '/')
       word.gsub!(/([A-Z\d]+)([A-Z][a-z])/, '\1_\2')
       word.gsub!(/([a-z\d])([A-Z])/, '\1_\2')
       word.tr!('-', '_')
       word.downcase!
       word
+    end
+
+    private
+
+    # `match?` was added in Ruby 2.4 this allows us to be backwards
+    # compatible with older Ruby versions
+    def matches(word)
+      if regexp.respond_to?(:match?)
+        regexp.match?(word)
+      else
+        regexp.match(word)
+      end
+    end
+
+    def camel_case_regexp
+      /[A-Z-]|::/
     end
   end
 end

--- a/lib/synchronized_model/support.rb
+++ b/lib/synchronized_model/support.rb
@@ -3,7 +3,9 @@ module SynchronizedModel
   module Support
     # Taken from ActiveSupport:Inflector.underscore
     def underscore(camel_cased_word)
-      return camel_cased_word unless matches_wrapper(camel_cased_word)
+      unless matches(/[A-Z-]|::/, camel_cased_word)
+        return camel_cased_word
+      end
       word = camel_cased_word.to_s.gsub('::', '/')
       word.gsub!(/([A-Z\d]+)([A-Z][a-z])/, '\1_\2')
       word.gsub!(/([a-z\d])([A-Z])/, '\1_\2')
@@ -16,16 +18,12 @@ module SynchronizedModel
 
     # `match?` was added in Ruby 2.4 this allows us to be backwards
     # compatible with older Ruby versions
-    def matches(word)
+    def matches(regexp, word)
       if regexp.respond_to?(:match?)
         regexp.match?(word)
       else
         regexp.match(word)
       end
-    end
-
-    def camel_case_regexp
-      /[A-Z-]|::/
     end
   end
 end

--- a/lib/synchronized_model/version.rb
+++ b/lib/synchronized_model/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SynchronizedModel
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 end


### PR DESCRIPTION
Gem is using .matches? method which was added in Ruby 2.4
It behaves the same as .matches however it's far faster.

Entity master however is not yet running on Ruby 2.4 so adding
fallback for when matches? isn't available to support it.

needed-by westernmilling/entity_master_app#229