### PR TITLE
Add rake task to publish models for seeding

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    synchronized_model (0.2.1)
+    synchronized_model (0.3.0)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -22,7 +22,14 @@ Or install it yourself as:
 
 ## Usage
 
-TODO: Write usage instructions here
+### Seeding New Apps with Table data
+- Run `rake synchronized_model:publish[ClassName]`
+
+### Resyncing for an added column
+- Run `rake synchronized_model:publish[ClassName, true]`
+- It will touch each record ensuring it's updated in the receivers and not ignored
+as a duplicate
+
 
 ## Development
 

--- a/lib/synchronized_model.rb
+++ b/lib/synchronized_model.rb
@@ -7,20 +7,23 @@ module SynchronizedModel
   autoload :MessageReceive, 'synchronized_model/message_receive'
   autoload :Message, 'synchronized_model/message'
   autoload :ModelMessage, 'synchronized_model/model_message'
+  autoload :Publish, 'synchronized_model/publish'
   autoload :PublishMixin, 'synchronized_model/publish_mixin'
   autoload :Support, 'synchronized_model/support'
 
   class << self
-    attr_accessor :logger, :receive_resource_classes
+    attr_accessor :logger, :publish_handler, :receive_resource_classes
     # ```ruby
     # SynchronizedModel.configure do |config|
     #   config.logger = Logger.new(STDOUT)
+    #   config.publish_handler = proc do |error|
+    #     Circuitry.publish("wm-otto-models", message)
+    #   end
     #   config.receive_resource_classes =
     #    {
     #       'item': Item,
     #       'location': Location
     #    }
-    #    config.publish = lambda -> { Circuitry.call }
     # end
     # ```
     def configure

--- a/lib/synchronized_model.rb
+++ b/lib/synchronized_model.rb
@@ -16,7 +16,7 @@ module SynchronizedModel
     # ```ruby
     # SynchronizedModel.configure do |config|
     #   config.logger = Logger.new(STDOUT)
-    #   config.publish_handler = proc do |error|
+    #   config.publish_handler = proc do |message|
     #     Circuitry.publish("wm-otto-models", message)
     #   end
     #   config.receive_resource_classes =

--- a/lib/synchronized_model.rb
+++ b/lib/synchronized_model.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'synchronized_model/version'
+require 'synchronized_model/railtie' if defined?(Rails)
 
 module SynchronizedModel
   autoload :MessageReceive, 'synchronized_model/message_receive'
@@ -19,6 +20,7 @@ module SynchronizedModel
     #       'item': Item,
     #       'location': Location
     #    }
+    #    config.publish = lambda -> { Circuitry.call }
     # end
     # ```
     def configure

--- a/lib/synchronized_model/publish.rb
+++ b/lib/synchronized_model/publish.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module SynchronizedModel
+  class Publish
+    attr_reader :model
+
+    def initialize(model)
+      @model = model
+    end
+
+    def call
+      message = SynchronizedModel::Message.new(model).call
+      SynchronizedModel.publish_handler.call(message)
+    end
+  end
+end

--- a/lib/synchronized_model/railtie.rb
+++ b/lib/synchronized_model/railtie.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+module SynchronizedModel
+  class Railtie < Rails::Railtie
+    rake_tasks do
+      load 'tasks/publish.rake'
+    end
+  end
+end

--- a/lib/synchronized_model/version.rb
+++ b/lib/synchronized_model/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SynchronizedModel
-  VERSION = '0.2.1'
+  VERSION = '0.3.0'
 end

--- a/lib/tasks/publish.rake
+++ b/lib/tasks/publish.rake
@@ -17,7 +17,8 @@ namespace :synchronized_model do
       # I'm thinking we make this an endpoint and load circuitry in with
       # a config endpoint
       # detail in readme
-      PublishModelService.new(model).call
+      SynchronizedModel::Publish.new(model).call
+      # PublishModelService.new(model).call
     end
   end
 end

--- a/lib/tasks/publish.rake
+++ b/lib/tasks/publish.rake
@@ -13,12 +13,8 @@ namespace :synchronized_model do
         model.update(updated_at: Time.zone.now)
       end
       logger.info "Publishing UUID: #{model.try(:uuid)}, ID: #{model.id}"
-      # This is not necessarily available.
-      # I'm thinking we make this an endpoint and load circuitry in with
-      # a config endpoint
-      # detail in readme
+
       SynchronizedModel::Publish.new(model).call
-      # PublishModelService.new(model).call
     end
   end
 end

--- a/lib/tasks/publish.rake
+++ b/lib/tasks/publish.rake
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+namespace :synchronized_model do
+  desc 'Publish all records for a model'
+  task :publish,
+       %i(model_class_string touch_records) => :environment do |_t, args|
+    logger = Logger.new(STDOUT)
+    model_class = Module.const_get(args.model_class_string)
+
+    logger.info "#{model_class.count} #{args.model_class_string} to publish"
+    model_class.find_each do |model|
+      if args.touch_records == 'true'
+        logger.info "Touching UUID: #{model.try(:uuid)}, ID: #{model.id}"
+        model.update(updated_at: Time.zone.now)
+      end
+      logger.info "Publishing UUID: #{model.try(:uuid)}, ID: #{model.id}"
+      # This is not necessarily available.
+      # I'm thinking we make this an endpoint and load circuitry in with
+      # a config endpoint
+      # detail in readme
+      PublishModelService.new(model).call
+    end
+  end
+end

--- a/spec/lib/synchronized_model/publish_spec.rb
+++ b/spec/lib/synchronized_model/publish_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+RSpec.describe SynchronizedModel::Publish do
+  class TestPublishModelClass
+    include SynchronizedModel::PublishMixin
+
+    attr_accessor :attributes
+
+    def initialize(attributes)
+      @attributes = attributes
+    end
+  end
+
+  let(:expected_attributes) do
+    { name: 'John Smith', visits: '12' }
+  end
+  let(:test_model) do
+    TestPublishModelClass.new(expected_attributes)
+  end
+  let(:publish_handler) { spy }
+
+  let(:instance) { described_class.new(test_model) }
+
+  describe '#call' do
+    before do
+      allow(publish_handler)
+        .to receive(:call)
+      allow(SynchronizedModel)
+        .to receive(:publish_handler)
+        .and_return(publish_handler)
+    end
+
+    subject { instance.call }
+
+    it 'calls publish handler with message' do
+      subject
+
+      expect(SynchronizedModel)
+        .to have_received(:publish_handler)
+      expect(publish_handler)
+        .to have_received(:call)
+        .with(instance_of(Hash))
+    end
+  end
+end


### PR DESCRIPTION
When a new application is setup it needs all previously created
records to have messages sent again for them. This adds a rake
task that will allow you to publish all records for any model
setup with the Publish mixin.

It also includes a touch option to update the updated_at timestamp
on the records so that the receiving systems will not ignore the
messages if they've already received them. This is useful in
some edge cases like if a new column is added in a receiving
system and it needs that column populated.

needed-by #7