### PR TITLE
Fix bug with ignored models not being handled correctly

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    synchronized_model (0.3.0)
+    synchronized_model (0.3.1)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/synchronized_model/message_receive.rb
+++ b/lib/synchronized_model/message_receive.rb
@@ -37,7 +37,7 @@ module SynchronizedModel
     end
 
     def log_model_not_found
-      log_message = "Skipped Message ID:#{message[:id]}. " \
+      log_message = "Skipped Message ID: #{message[:id]}. " \
       "No #{message[:resource]} model configured with SynchronizedModel"
       SynchronizedModel.logger.info(log_message)
     end

--- a/lib/synchronized_model/message_receive.rb
+++ b/lib/synchronized_model/message_receive.rb
@@ -8,9 +8,18 @@ module SynchronizedModel
     end
 
     def call
-      model = SynchronizedModel::ModelMessage.new(message).model
-      model.record_timestamps = false
+      if model
+        update_model
+      else
+        log_model_not_found
+      end
+    end
+
+    private
+
+    def update_model
       if chronological_update?(model)
+        model.record_timestamps = false
         model.save!
       else
         log_message = "Outdated message for #{model.class} " \
@@ -19,10 +28,18 @@ module SynchronizedModel
       end
     end
 
-    private
-
     def chronological_update?(model)
       !(model.updated_at_was && model.updated_at_was >= model.updated_at)
+    end
+
+    def model
+      @model ||= SynchronizedModel::ModelMessage.new(message).model
+    end
+
+    def log_model_not_found
+      log_message = "Skipped Message ID:#{message[:id]}. " \
+      "No #{message[:resource]} model configured with SynchronizedModel"
+      SynchronizedModel.logger.info(log_message)
     end
   end
 end

--- a/lib/synchronized_model/model_message.rb
+++ b/lib/synchronized_model/model_message.rb
@@ -16,25 +16,13 @@ module SynchronizedModel
     end
 
     def model
-      @model ||= resource_class.from_queue_payload(payload)
+      @model ||= resource_class&.from_queue_payload(payload)
     end
 
     protected
 
     def resource_class
-      SynchronizedModel.receive_resource_classes.fetch(
-        resource.to_sym, NullModel
-      )
-    end
-
-    class NullModel
-      def self.from_queue_payload(_payload); NullModel.new; end
-
-      def self.find_by(_hash); nil; end
-
-      def save!; end
-
-      def updated_at; nil; end
+      SynchronizedModel.receive_resource_classes[resource.to_sym]
     end
   end
 end

--- a/lib/synchronized_model/version.rb
+++ b/lib/synchronized_model/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SynchronizedModel
-  VERSION = '0.3.0'
+  VERSION = '0.3.1'
 end

--- a/spec/lib/synchronized_model/message_receive_spec.rb
+++ b/spec/lib/synchronized_model/message_receive_spec.rb
@@ -100,6 +100,10 @@ RSpec.describe SynchronizedModel::MessageReceive do
     context "the model isn't configured" do
       let(:updated_at_was) { nil }
       let(:updated_at) { nil }
+      let(:expected_log_message) do
+        "Skipped Message ID: #{message[:id]}. " \
+        "No #{message[:resource]} model configured with SynchronizedModel"
+      end
       let(:logger_spy) { spy }
       let(:mock_model) { nil }
 
@@ -118,6 +122,7 @@ RSpec.describe SynchronizedModel::MessageReceive do
           .to have_received(:logger)
         expect(logger_spy)
           .to have_received(:info)
+          .with(expected_log_message)
       end
     end
   end

--- a/spec/lib/synchronized_model/message_receive_spec.rb
+++ b/spec/lib/synchronized_model/message_receive_spec.rb
@@ -100,11 +100,8 @@ RSpec.describe SynchronizedModel::MessageReceive do
     context "the model isn't configured" do
       let(:updated_at_was) { nil }
       let(:updated_at) { nil }
-      let(:expected_log_message) do
-        'message'
-      end
       let(:logger_spy) { spy }
-      let(:mock_model) { spy }
+      let(:mock_model) { nil }
 
       before do
         allow(SynchronizedModel)
@@ -114,15 +111,13 @@ RSpec.describe SynchronizedModel::MessageReceive do
           .to receive(:info)
       end
 
-      it 'does not call save and logs that the model was not configured' do
+      it 'logs that the model was not configured' do
         subject
 
-        expect(mock_model).to_not have_received(:save!)
         expect(SynchronizedModel)
           .to have_received(:logger)
         expect(logger_spy)
           .to have_received(:info)
-          .with(expected_log_message)
       end
     end
   end

--- a/spec/lib/synchronized_model/message_receive_spec.rb
+++ b/spec/lib/synchronized_model/message_receive_spec.rb
@@ -96,5 +96,34 @@ RSpec.describe SynchronizedModel::MessageReceive do
         expect(mock_model).to_not have_received(:save!)
       end
     end
+
+    context "the model isn't configured" do
+      let(:updated_at_was) { nil }
+      let(:updated_at) { nil }
+      let(:expected_log_message) do
+        'message'
+      end
+      let(:logger_spy) { spy }
+      let(:mock_model) { spy }
+
+      before do
+        allow(SynchronizedModel)
+          .to receive(:logger)
+          .and_return(logger_spy)
+        allow(logger_spy)
+          .to receive(:info)
+      end
+
+      it 'does not call save and logs that the model was not configured' do
+        subject
+
+        expect(mock_model).to_not have_received(:save!)
+        expect(SynchronizedModel)
+          .to have_received(:logger)
+        expect(logger_spy)
+          .to have_received(:info)
+          .with(expected_log_message)
+      end
+    end
   end
 end


### PR DESCRIPTION
When a message for a model that hasn't been configured in the
current application is received it gracefully logs that miss.

Resolves an exception that currently fires when those messages
come in.

needed-by #6