### PR TITLE
Refactor to work with Sequel and ActiveRecord.

### DIFF
--- a/lib/synchronized_model/message_receive.rb
+++ b/lib/synchronized_model/message_receive.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'pry'
 module SynchronizedModel
   class MessageReceive
     attr_reader :message

--- a/lib/synchronized_model/publish_mixin.rb
+++ b/lib/synchronized_model/publish_mixin.rb
@@ -3,7 +3,11 @@
 module SynchronizedModel
   module PublishMixin
     def to_message_payload
-      attributes.merge(additional_message_attributes)
+      if defined? attributes
+        attributes.merge(additional_message_attributes)
+      else
+        values.merge(additional_message_attributes)
+      end
     end
 
     private

--- a/lib/synchronized_model/version.rb
+++ b/lib/synchronized_model/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SynchronizedModel
-  VERSION = '0.3.1'
+  VERSION = '0.3.2'
 end

--- a/spec/lib/synchronized_model/message_receive_spec.rb
+++ b/spec/lib/synchronized_model/message_receive_spec.rb
@@ -41,6 +41,15 @@ RSpec.describe SynchronizedModel::MessageReceive do
       model
     end
 
+    let(:mock_model_sequel) do
+      model = TestModel.new
+      allow(model).to receive(:save!)
+      allow(model).to receive(:column_change).and_return(
+        [updated_at_was, updated_at]
+      )
+      model
+    end
+
     let(:logger_mock) do
       logger = double
       allow(logger).to receive(:info)
@@ -57,9 +66,6 @@ RSpec.describe SynchronizedModel::MessageReceive do
             'test_model': TestModel
           }
       end
-      allow(mock_message_model)
-        .to receive(:model)
-        .and_return(mock_model)
       allow(SynchronizedModel::ModelMessage)
         .to receive(:new)
         .and_return(mock_message_model)
@@ -67,65 +73,89 @@ RSpec.describe SynchronizedModel::MessageReceive do
 
     subject { SynchronizedModel::MessageReceive.new(message).call }
 
-    context 'it\'s a chronological_update' do
-      let(:updated_at_was) { Time.now.to_i }
-      let(:updated_at) { Time.now.to_i + 100 }
-
-      it 'calls save!' do
-        subject
-
-        expect(mock_model).to have_received(:save!)
-      end
-    end
-
-    context 'the message is older than the model' do
-      let(:updated_at_was) { Time.now.to_i + 10_000 }
-      let(:updated_at) { Time.now.to_i }
-
-      it 'does not call save!' do
-        subject
-
-        expect(mock_model).to_not have_received(:save!)
-      end
-    end
-
-    context 'the message is the same age as the model' do
-      let(:updated_at_was) { Time.now.to_i }
-      let(:updated_at) { Time.now.to_i }
-
-      it 'does not call save!' do
-        subject
-
-        expect(mock_model).to_not have_received(:save!)
-      end
-    end
-
-    context "the model isn't configured" do
-      let(:updated_at_was) { nil }
-      let(:updated_at) { nil }
-      let(:expected_log_message) do
-        "Skipped Message ID: #{message[:id]}. " \
-        "No #{message[:resource]} model configured with SynchronizedModel"
-      end
-      let(:logger_spy) { spy }
-      let(:mock_model) { nil }
-
+    context 'with a Sequel model' do
       before do
-        allow(SynchronizedModel)
-          .to receive(:logger)
-          .and_return(logger_spy)
-        allow(logger_spy)
-          .to receive(:info)
+        allow(mock_message_model)
+          .to receive(:model).and_return(mock_model_sequel)
       end
 
-      it 'logs that the model was not configured' do
-        subject
+      context 'it\'s a chronological_update' do
+        let(:updated_at_was) { Time.now.to_i }
+        let(:updated_at) { Time.now.to_i + 100 }
 
-        expect(SynchronizedModel)
-          .to have_received(:logger)
-        expect(logger_spy)
-          .to have_received(:info)
-          .with(expected_log_message)
+        it 'calls save!' do
+          subject
+
+          expect(mock_model_sequel).to have_received(:save!)
+        end
+      end
+    end
+
+    context 'with an ActiveRecord model' do
+      before do
+        allow(mock_message_model).to receive(:model).and_return(mock_model)
+      end
+
+      context 'it\'s a chronological_update' do
+        let(:updated_at_was) { Time.now.to_i }
+        let(:updated_at) { Time.now.to_i + 100 }
+
+        it 'calls save!' do
+          subject
+
+          expect(mock_model).to have_received(:save!)
+        end
+      end
+
+      context 'the message is older than the model' do
+        let(:updated_at_was) { Time.now.to_i + 10_000 }
+        let(:updated_at) { Time.now.to_i }
+
+        it 'does not call save!' do
+          subject
+
+          expect(mock_model).to_not have_received(:save!)
+        end
+      end
+
+      context 'the message is the same age as the model' do
+        let(:updated_at_was) { Time.now.to_i }
+        let(:updated_at) { Time.now.to_i }
+
+        it 'does not call save!' do
+          subject
+
+          expect(mock_model).to_not have_received(:save!)
+        end
+      end
+
+      context "the model isn't configured" do
+        let(:updated_at_was) { nil }
+        let(:updated_at) { nil }
+        let(:expected_log_message) do
+          "Skipped Message ID: #{message[:id]}. " \
+          "No #{message[:resource]} model configured with SynchronizedModel"
+        end
+        let(:logger_spy) { spy }
+        let(:mock_model) { nil }
+
+        before do
+          allow(SynchronizedModel)
+            .to receive(:logger)
+            .and_return(logger_spy)
+          allow(logger_spy)
+            .to receive(:info)
+        end
+
+        it 'logs that the model was not configured' do
+          subject
+
+          expect(SynchronizedModel)
+            .to have_received(:logger)
+          expect(logger_spy)
+            .to have_received(:info)
+            .with(expected_log_message)
+        end
       end
     end
   end

--- a/spec/lib/synchronized_model/message_receive_spec.rb
+++ b/spec/lib/synchronized_model/message_receive_spec.rb
@@ -47,6 +47,9 @@ RSpec.describe SynchronizedModel::MessageReceive do
       allow(model).to receive(:column_change).and_return(
         [updated_at_was, updated_at]
       )
+      allow(model).to receive(:additional_message_attributes).and_return(
+        {additional_key: 'Test message'}
+      )
       model
     end
 

--- a/spec/lib/synchronized_model/message_receive_spec.rb
+++ b/spec/lib/synchronized_model/message_receive_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe SynchronizedModel::MessageReceive do
     def save!; end
 
     def updated_at; nil; end
+
+    def updated_at=(_value); nil; end
   end
 
   describe '#call' do

--- a/spec/lib/synchronized_model/publish_mixin_spec.rb
+++ b/spec/lib/synchronized_model/publish_mixin_spec.rb
@@ -27,6 +27,20 @@ RSpec.describe SynchronizedModel::PublishMixin do
     end
   end
 
+  class SequelTestClassWithAdditionalAttributes
+    include SynchronizedModel::PublishMixin
+
+    attr_accessor :values
+
+    def initialize(values)
+      @values = values
+    end
+
+    def additional_message_attributes
+      { title: 'Senior' }
+    end
+  end
+
   describe '#to_message_payload' do
     let(:expected_attributes) do
       { name: 'John Smith', visits: '12' }
@@ -51,6 +65,23 @@ RSpec.describe SynchronizedModel::PublishMixin do
 
       subject do
         TestClassWithAdditionalAttributes
+          .new(expected_attributes)
+          .to_message_payload
+      end
+
+      it 'returns attributes hash' do
+        expect(subject)
+          .to  eq(expected_attributes.merge(expected_additional_attributes))
+      end
+    end
+
+    context 'with additional attributes on a Sequel model' do
+      let(:expected_additional_attributes) do
+        { title: 'Senior' }
+      end
+
+      subject do
+        SequelTestClassWithAdditionalAttributes
           .new(expected_attributes)
           .to_message_payload
       end


### PR DESCRIPTION
Refactor to work with Sequel and ActiveRecord.
 - This change is needed because there were syntaxes that only work with ActiveRecord. Now the functionality will be extended to Sequel as well. 

Needed-by: [#126](https://github.com/westernmilling/contracto/issues/126)